### PR TITLE
Fix clobbering of ecb-activate-hook outside of the customize framework

### DIFF
--- a/ecb-eshell.el
+++ b/ecb-eshell.el
@@ -387,7 +387,8 @@ enlarge the compile-window over half of the frame-height and also not below
              (equal frame ecb-frame))
     (ignore-errors (ecb-eshell-recenter))))
 
-(add-hook 'ecb-activate-hook 'ecb-eshell-auto-activate-hook)
+;; Adding this hook clobbered any attempt to customize the variable
+;; (add-hook 'ecb-activate-hook 'ecb-eshell-auto-activate-hook)
 
 (silentcomp-provide 'ecb-eshell)
 


### PR DESCRIPTION
This change was originally reported to Alex Ott’s GitHub.  This was
filed as Issue #21 in ecb-home.