### PR TITLE
bug fix : Compilation windows no longer displayed issue #51

### DIFF
--- a/ecb-compatibility.el
+++ b/ecb-compatibility.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t; -*-
 ;;; ecb-compatibility.el --- ECB-compatibility for other packages
 
 ;; Copyright (C) 2000 - 2015 Jesper Nordenberg,
@@ -114,19 +115,19 @@ BUFFER is displayed in an edit-window!"
              (ecb-point-in-dedicated-special-buffer))
     (ecb-select-edit-window)))
 
-;(defecb-advice electric-buffer-list before ecb-compatibility-advices
-;  "Ensures that the electric-* commands work well with ECB."
-;  (when (and ecb-minor-mode
-;             (equal (selected-frame) ecb-frame)
-;             (ecb-point-in-dedicated-special-buffer))
-;    (ecb-select-edit-window)))
-;
-;(defecb-advice electric-buffer-list after ecb-compatibility-advices
-;  "Ensures that the electric-* commands work well with ECB."
-;  (when (and ecb-minor-mode
-;             (equal (selected-frame) ecb-frame))
-;    (if (ecb-buffer-obj "*Buffer List*")
-;        (bury-buffer (ecb-buffer-obj "*Buffer List*")))))
+(defecb-advice electric-buffer-list before ecb-compatibility-advices
+  "Ensures that the electric-* commands work well with ECB."
+  (when (and ecb-minor-mode
+             (equal (selected-frame) ecb-frame)
+             (ecb-point-in-dedicated-special-buffer))
+    (ecb-select-edit-window)))
+
+(defecb-advice electric-buffer-list after ecb-compatibility-advices
+  "Ensures that the electric-* commands work well with ECB."
+  (when (and ecb-minor-mode
+             (equal (selected-frame) ecb-frame))
+    (if (ecb-buffer-obj "*Buffer List*")
+        (bury-buffer (ecb-buffer-obj "*Buffer List*")))))
 
 ;; package master.el
 

--- a/ecb-layout.el
+++ b/ecb-layout.el
@@ -2479,7 +2479,7 @@ If called for other frames it works like the original version."
                            ;; (because all other windows are temporally
                            ;; dedicated) use exactly this window and there
                            ;; is no need to split it
-                           )
+                           ad-do-it)
                        ;; making the edit-window(s) not dedicated
                        (mapc (function (lambda (w)
                                          (set-window-dedicated-p w nil)))


### PR DESCRIPTION
I added ad-do-it again in ecb-layout.el
but I am not sure where the differences in ecb-compatibility came from, I have removed the comment as it does not seem to be a problem
